### PR TITLE
drop execute() override workaround

### DIFF
--- a/src/main/java/org/codehaus/mojo/aspectj/AjcReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcReportMojo.java
@@ -207,17 +207,6 @@ public class AjcReportMojo
     @Parameter( readonly = true, required = true, defaultValue = "${plugin.artifacts}" )
     private List<Artifact> pluginArtifacts;
 
-    @Override
-    public void execute() throws MojoExecutionException {
-        //super.execute();
-        try {
-            executeReport(Locale.getDefault());
-        }
-        catch (MavenReportException e) {
-            throw new MojoExecutionException(e);
-        }
-    }
-
     /**
      * Executes this ajdoc-report generation.
      */


### PR DESCRIPTION
see discussion https://lists.apache.org/thread/ko6g9sgwysm46t9j0nqw4bj6krj72q2b

for quick run limited to the failing IT:

```
mvn -Dinvoker.test=CreateReport clean verify -P integration-test
```

issue visible in `target/it/CreateReport/build.log`:
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.maven.doxia.tools.SiteTool.getSiteLocales(String)" because "this.siteTool" is null
    at org.apache.maven.reporting.AbstractMavenReport.getLocale (AbstractMavenReport.java:400)
```

`AbstractMavenReport.siteTool` is not injected as it should as it is declared as `@Component` https://github.com/apache/maven-reporting-impl/blob/maven-reporting-impl-4.0.0-M10/src/main/java/org/apache/maven/reporting/AbstractMavenReport.java#L150